### PR TITLE
fix: renovate json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every day"],
+  "prCreation": "immediate",
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "groupName": "Cargo dependencies",
       "matchManagers": ["cargo"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "semanticCommitType": "deps:"
     },
     {
       "groupName": "GitHub Actions",
-      "matchManagers": ["github-actions"]
+      "matchManagers": ["github-actions"],
+      "semanticCommitType": "deps:"
     }
   ]
 }


### PR DESCRIPTION
## What

Fixes renovate json config.

## Why

It's broken.

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Tested locally with `dx serve --desktop`
